### PR TITLE
using postman you can set query params for location and search

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -109,6 +109,8 @@ class Products(ViewSet):
         serializer = ProductSerializer(
             new_product, context={'request': request})
 
+        
+
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, pk=None):
@@ -150,6 +152,7 @@ class Products(ViewSet):
                 }
             }
         """
+
         try:
             product = Product.objects.get(pk=pk)
             serializer = ProductSerializer(product, context={'request': request})
@@ -252,7 +255,9 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
-
+        # Support filtering products by location
+        location = self.request.query_params.get('location', None)
+        
         if order is not None:
             order_filter = order
 
@@ -275,6 +280,10 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if location is not None:
+            products = products.filter(location__contains=location)
+        
 
         serializer = ProductSerializer(
             products, many=True, context={'request': request})


### PR DESCRIPTION
when using postman you can set query params for location and search.  This search feature will search for locations that contain the key letter or full name of the location

## Changes

- in the product.py views I added a If statement to see if there was a location query
- if location query was not none it would search by letter or full name of location

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [1] `git fetch --all`
- [2] `git checkout ap-queryProductsByLocations`
- [3] in postman GET Request Method `http://localhost:8000/products?location={letter or full location name}`
- [4] should return products related to the location query


## Related Issues

- Fixes #14 
