### PR TITLE
made small edit to be able to delete cart itmes

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -61,7 +61,6 @@ class LineItems(ViewSet):
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
     def destroy(self, request, pk=None):
-        if request.method == "DELETE":
             """
             @api {DELETE} /cart/:id DELETE line item from cart
             @apiName RemoveLineItem
@@ -75,15 +74,16 @@ class LineItems(ViewSet):
             @apiSuccessExample {json} Success
                 HTTP/1.1 204 No Content
             """
-        try:
-            customer = Customer.objects.get(user=request.auth.user)
-            order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
-            order_product.delete()
+            if request.method == "DELETE":
+                try:
+                    customer = Customer.objects.get(user=request.auth.user)
+                    order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+                    order_product.delete()
 
-            return Response({}, status=status.HTTP_204_NO_CONTENT)
+                    return Response({}, status=status.HTTP_204_NO_CONTENT)
 
-        except OrderProduct.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+                except OrderProduct.DoesNotExist as ex:
+                    return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
-        except Exception as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+                except Exception as ex:
+                    return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -61,22 +61,24 @@ class LineItems(ViewSet):
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
     def destroy(self, request, pk=None):
-        """
-        @api {DELETE} /cart/:id DELETE line item from cart
-        @apiName RemoveLineItem
-        @apiGroup ShoppingCart
+        if request.method == "DELETE":
+            """
+            @api {DELETE} /cart/:id DELETE line item from cart
+            @apiName RemoveLineItem
+            @apiGroup ShoppingCart
 
-        @apiHeader {String} Authorization Auth token
-        @apiHeaderExample {String} Authorization
-            Token 9ba45f09651c5b0c404f37a2d2572c026c146611
+            @apiHeader {String} Authorization Auth token
+            @apiHeaderExample {String} Authorization
+                Token 9ba45f09651c5b0c404f37a2d2572c026c146611
 
-        @apiParam {id} id Product Id to remove from cart
-        @apiSuccessExample {json} Success
-            HTTP/1.1 204 No Content
-        """
+            @apiParam {id} id Product Id to remove from cart
+            @apiSuccessExample {json} Success
+                HTTP/1.1 204 No Content
+            """
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
This Issue ticket solves issue#20 where a customer could not delete lineItems from their cart.

## Changes

- In `bangazonapi/views/lineitem.py` I added `if request.method == "DELETE":`
- this allows the `DELETE` request to be made and `try` to delete the lineitem with the associated `id/pk`



## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] `git fetch --all`
- [ ] `git checkout ap-deleteItemFromCart`
- [ ] In `Postman` Make sure the user has items in their cart
- [ ] In `Postman` DELETE `http://localhost:8000/lineitems/n` where `n` is equal to the id of the lineitem in the Customers cart
- [ ] Then SEND
- [ ] THEN GET `http://localhost:8000/profile/cart` SEND and the requested line item that was deleted should be missing/ deleted


## Related Issues


- Fixes #20