### PR TITLE
issue fix when querying data for minimum sold

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -275,7 +275,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Original Issue: when making a query for number sold would return items that sold less than the query.

Fix: changed the `if` statement to check number sold to be greater than number sold query.

## Changes

In `bangazonapi/views/product.py`
- `if product.number_sold <= int(number_sold):`
- changed to
- `if product.number_sold >= int(number_sold):`


## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] `git fetch --all`
- [ ] `git checkout ap-minimumProductsSold`
- [ ] In `Postman` make a query for minimum products sold `GET` `http://localhost:8000/products?number_sold=2` `SEND`

Should see products that have sold 2 or more


## Related Issues

- Fixes #21