### PR TITLE
fixed payment info

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
When checking for the issue on why dates were being returned wrong in the database I found in the `Payment(ViewSet)`

## Changes

- In the `def create` in `bangazonapi/views/paymenttype.py`
- Changed then way that the payment is created receives its information from the client
- `new_payment.expiration_date = request.data["create_date"]
    new_payment.create_date = request.data["expiration_date"]`
- Changed to:
- `new_payment.expiration_date = request.data["expiration_date"]
    new_payment.create_date = request.data["create_date"]`

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] `git fetch --all`
- [ ] `git checkout ap-fixPayementDate`
- [ ] In `Postman` create a new payment and date should be returned back correctly in the Postbody.

## Related Issues

- Fixes #85
- Fixes #22