### PR TITLE
Ap show only current user payment type

### DIFF
--- a/bangazonapi/models/product.py
+++ b/bangazonapi/models/product.py
@@ -15,7 +15,8 @@ class Product(SafeDeleteModel):
     customer = models.ForeignKey(
         Customer, on_delete=models.DO_NOTHING, related_name='products')
     price = models.FloatField(
-        validators=[MinValueValidator(0.00), MaxValueValidator(10000.00)],)
+        validators=[MinValueValidator(0.00), MaxValueValidator(17500.00)],
+        )
     description = models.CharField(max_length=255,)
     quantity = models.IntegerField(validators=[MinValueValidator(0)],)
     created_date = models.DateField(auto_now_add=True)

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -81,10 +81,10 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer_id = Customer.objects.get(user=request.auth.user) 
 
         if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+            payment_types = payment_types.filter(customer__id=customer_id.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -103,7 +103,7 @@ class Products(ViewSet):
             data = ContentFile(base64.b64decode(imgstr), name=f'{new_product.id}-{request.data["name"]}.{ext}')
 
             new_product.image_path = data
-
+        new_product.clean_fields(exclude='image_path')
         new_product.save()
 
         serializer = ProductSerializer(
@@ -189,6 +189,8 @@ class Products(ViewSet):
 
         product_category = ProductCategory.objects.get(pk=request.data["category_id"])
         product.category = product_category
+        
+        product.clean_fields(exclude='image_path')
         product.save()
 
         return Response({}, status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Original code would return a list of all payment types not just the auth user payment types

## Changes

- In `bangazonapi/view/paymenttype.py`
- the `list` function for `GET` request for payments needed the `if` statement adjusted
- instead of `customer_id = self.request.query_params.get('customer', None)` where we would set the query parameter for the customer_id in the `GET` URL in `Postman`
- I changed it to `customer_id = Customer.objects.get(user=request.auth.user) ` 
- This sets customer_id to the currently logged in authenticated individual.
- Then in the `if` statement below `if customer_id is not None:
            payment_types = payment_types.filter(customer__id=customer_id.id)`
- Where I still needed to set the `customer_id` `id` and not the whole object
- This would be beneficial to change later so that it makes it more readable either change variable names or change the way I set `customer_id`


## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] `git fetch --all`
- [ ] `git checkout ap-showOnlyCurrentUserPaymentType`
- [ ] In `Postman` make sure to use an `Auth Token`
- [ ] `GET` `http://localhost:8000/paymenttypes` `SEND`
- [ ] If that user has a payment type saved then it should show their payment type and theirs only


## Related Issues

- Fixes #18
