### PR TITLE
created code to show products in ASC order from minumu query target

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -255,6 +255,7 @@ class Products(ViewSet):
         order = self.request.query_params.get('order_by', None)
         direction = self.request.query_params.get('direction', None)
         number_sold = self.request.query_params.get('number_sold', None)
+        price = self.request.query_params.get('price', None)
         # Support filtering products by location
         location = self.request.query_params.get('location', None)
         
@@ -280,6 +281,14 @@ class Products(ViewSet):
                 return False
 
             products = filter(sold_filter, products)
+
+        if price is not None:
+            def price_filter(product):
+                if product.price >= int(price):
+                    return True
+                return False
+
+            products = filter(price_filter, products.order_by("price"))
 
         if location is not None:
             products = products.filter(location__contains=location)


### PR DESCRIPTION
when querying products by price products that should be returned are `Greater` than or `equal` to the query target specified.

## Changes

- In `bangazonapi/views/product.py` added if statement to filter by price query
- If statement was also built to return products back in `ASCENDING` order


## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] `git fetch --all`
- [ ] `git checkout ap-listProductsOverSpecPrice`
- [ ] In `Postman` `GET` `http://localhost:8000/products?price=655` `SEND`
- [ ] returned body should be a list of products in ascending order starting at the specified query price


## Related Issues

- Fixes #17